### PR TITLE
Don't delete initial input value

### DIFF
--- a/src/ngAutocomplete.js
+++ b/src/ngAutocomplete.js
@@ -78,7 +78,6 @@ angular.module( "ngAutocomplete", [])
         scope.$watch(scope.watchOptions, function () {
           initOpts()
           newAutocomplete()
-          element[0].value = '';
           scope.ngAutocomplete = element.val();
         }, true);
       }


### PR DESCRIPTION
If used in a form with an address field, initial value is usually needed. This seems to solve it.
