### PR TITLE
Blur autocomplete input after enter press

### DIFF
--- a/src/ngAutocomplete.js
+++ b/src/ngAutocomplete.js
@@ -97,7 +97,8 @@ angular.module( "ngAutocomplete", [])
             }
             else {
               if (watchEnter) {
-                getPlace(result)
+                getPlace(result);
+                element[0].blur();
               }
             }
           }
@@ -164,3 +165,4 @@ angular.module( "ngAutocomplete", [])
       }
     };
   });
+


### PR DESCRIPTION
I don't now if this is desired behaviour for all use cases, but on mobile this change closes the keyboard after hitting Enter/Go.
