### PR TITLE
Changed watchOutFocus to use the 'blur' event instead of 'focusout'

### DIFF
--- a/src/ngAutocomplete.js
+++ b/src/ngAutocomplete.js
@@ -134,9 +134,9 @@ angular.module( "ngAutocomplete", [])
                           scope.details = detailsResult;
 
                           //on focusout the value reverts, need to set it again.
-                          var watchFocusOut = element.on('blur', function(event) {
+                          var watchFocusOut = element.on('focusout', function(event) {
                             element.val(detailsResult.formatted_address);
-                            element.unbind('blur')
+                            element.unbind('focusout')
                           })
 
                         });

--- a/src/ngAutocomplete.js
+++ b/src/ngAutocomplete.js
@@ -134,9 +134,9 @@ angular.module( "ngAutocomplete", [])
                           scope.details = detailsResult;
 
                           //on focusout the value reverts, need to set it again.
-                          var watchFocusOut = element.on('focusout', function(event) {
+                          var watchFocusOut = element.on('blur', function(event) {
                             element.val(detailsResult.formatted_address);
-                            element.unbind('focusout')
+                            element.unbind('blur')
                           })
 
                         });


### PR DESCRIPTION
The 'focusout' event doesnt appear to fire so I switched to 'blur'
Tested in Chrome V: 35.0.1916.153 and Safari V: 7.0.4 (9537.76.4) on MacOS V: 10.9.3
