### PR TITLE
Country restriction when using getPlacePredictions

### DIFF
--- a/src/ngAutocomplete.js
+++ b/src/ngAutocomplete.js
@@ -110,7 +110,8 @@ angular.module( "ngAutocomplete", [])
             autocompleteService.getPlacePredictions(
               {
                 input: result.name,
-                offset: result.name.length
+                offset: result.name.length,
+                componentRestrictions: opts.componentRestrictions
               },
               function listentoresult(list, status) {
                 if(list == null || list.length == 0) {


### PR DESCRIPTION
Take restrictions regarding country to search within also into account when using getPlacePredictions. 

Noticed that when I for instance set country restriction to Sweden (SE) and watchEnter to true and then type "si" and press enter, I get Singapore as a suggestion. This code change seems to fix this issue.
