### PR TITLE
emit "ngAutocomplete:place_changed" with Google's "place_changed" event

### DIFF
--- a/src/ngAutocomplete.js
+++ b/src/ngAutocomplete.js
@@ -101,6 +101,9 @@ angular.module( "ngAutocomplete", [])
               }
             }
           }
+
+          // Say our scope we have a result
+          scope.$emit('ngAutocomplete:place_changed', result);
         })
 
         //function to get retrieve the autocompletes first result using the AutocompleteService 


### PR DESCRIPTION
I know there is already a PR about that (https://github.com/penghou620/ngAutocomplete/commit/10e8d9fa2ab951f370566ced0a868857c5dfbb96) but I think this one has a different approach, I prefer get the sended result directly from the emit event than take it back from the scope.

```
// Simply get the directive result on this event
$scope.$on('ngAutocomplete:place_changed', function(result) {
    $log.info('Google's places results : ', result);
});
```

It's fate is in your hands \o/
