### PR TITLE
Adding types parameter the getPlacesPrediction call

### DIFF
--- a/src/ngAutocomplete.js
+++ b/src/ngAutocomplete.js
@@ -110,7 +110,8 @@ angular.module( "ngAutocomplete", [])
             autocompleteService.getPlacePredictions(
               {
                 input: result.name,
-                offset: result.name.length
+                offset: result.name.length,
+                types: [scope.options.types]
               },
               function listentoresult(list, status) {
                 if(list == null || list.length == 0) {


### PR DESCRIPTION
… used when the watchEnter parameter is true.

This makes sure that the autoselected first index is the same as the displayed autocomplete results.
